### PR TITLE
Kannel-HA bearerbox versions

### DIFF
--- a/kannel_exporter.py
+++ b/kannel_exporter.py
@@ -39,6 +39,8 @@ def bearerbox_version(version):
         # strip 'Kannel bearerbox version ' (length 25)
         if version.find('Kannel bearerbox version ') == 0:
             version = version[25:].strip('`').rstrip('\'.')
+        elif version.find('Kannel-HA bearerbox version ') == 0:
+            version = version[25:].strip('`').rstrip('\'.')
         else:
             logger.warning("Bearerbox version could not be found. " +
                            "Version value set to empty string.")

--- a/kannel_exporter.py
+++ b/kannel_exporter.py
@@ -40,7 +40,7 @@ def bearerbox_version(version):
         if version.find('Kannel bearerbox version ') == 0:
             version = version[25:].strip('`').rstrip('\'.')
         elif version.find('Kannel-HA bearerbox version ') == 0:
-            version = version[25:].strip('`').rstrip('\'.')
+            version = version[28:].strip('`').rstrip('\'.')
         else:
             logger.warning("Bearerbox version could not be found. " +
                            "Version value set to empty string.")


### PR DESCRIPTION
Catch Kannel-HA bearerbox versions, as below is a sample:
Kannel-HA bearerbox version `xxx-xxxx-xxx'.