### PR TITLE
Expose smsc uptime metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Works with Kannel 1.4.4 or greater.
 ## Usage
 ```
 kannel_exporter.py [-h] [--target TARGET] [--port PORT]
-                   [--filter-smscs] [--collect-wdp] [--collect-box-uptime]
+                   [--filter-smscs] [--collect-wdp]
+                   [--collect-box-uptime] [--collect-smsc-uptime]
                    [--box-connection-types BOX_CONNECTIONS [BOX_CONNECTIONS ...]]
                    [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-v]
                    [--password PASSWORD | --password-file PASSWORD_FILE]
@@ -28,6 +29,7 @@ kannel_exporter.py [-h] [--target TARGET] [--port PORT]
   --filter-smscs         Filter out SMSC metrics
   --collect-wdp          Collect WDP metrics
   --collect-box-uptime   Collect boxes uptime metrics
+  --collect-smsc-uptime  Collect SMSCs uptime metrics
   --box-connection-types List of box connection types. (default wapbox, smsbox)
   --log-level LEVEL      Define the logging level
   -v, --version          Display version information and exit

--- a/kannel_exporter.py
+++ b/kannel_exporter.py
@@ -137,11 +137,13 @@ class KannelCollector:
     def _collect_box_uptime(box_details, box, tuplkey):
         # Helper method to collect box uptime metrics.
         # In case of multiple boxes with same type, id and host,
-        # only the uptime of the first occurence will be exposed
-        # in order to avoid duplicates.
-        if tuplkey in box_details.keys():
-            if 'uptime' not in box_details[tuplkey].keys():
-                box_details[tuplkey]['uptime'] = uptime_to_secs(box['status'])
+        # only the lowest uptime value be exposed in order to avoid duplicates.
+        uptime = uptime_to_secs(box['status'])
+
+        if tuplkey in box_details:
+            if ('uptime' not in box_details[tuplkey] or
+                    uptime < box_details[tuplkey]['uptime']):
+                box_details[tuplkey]['uptime'] = uptime
         else:
             box_details[tuplkey] = {}
             box_details[tuplkey]['uptime'] = uptime_to_secs(box['status'])

--- a/kannel_exporter.py
+++ b/kannel_exporter.py
@@ -193,8 +193,8 @@ class KannelCollector:
                 tuplkey = (box['type'], box['id'], box['IP'])
 
                 # some type of boxes (e.g wapbox) don't have queues.
-                if 'queue' in box.keys():
-                    if tuplkey not in box_details.keys():
+                if 'queue' in box:
+                    if tuplkey not in box_details:
                         box_details[tuplkey] = {}
                     box_details[tuplkey]['queue'] = (box_details[tuplkey].get('queue', 0)
                                                      + int(box['queue']))
@@ -209,7 +209,7 @@ class KannelCollector:
 
         for key, value in box_details.items():
             box_labels = {'type': key[0], 'id': key[1], 'ipaddr': key[2]}
-            if 'queue' in value.keys():
+            if 'queue' in value:
                 metrics['box_queue'].add_sample('bearerbox_box_queue',
                                                 value=value['queue'],
                                                 labels=box_labels)
@@ -275,7 +275,7 @@ class KannelCollector:
                                                                          smsc['status'])
 
                 # kannel 1.5 exposes metrics in a different format
-                if 'sms' not in smsc.keys():
+                if 'sms' not in smsc:
                     aggreg[smscid]['sms']['received'] = (aggreg[smscid]['sms'].get('received', 0)
                                                          + int(smsc['received']['sms']))
                     aggreg[smscid]['sms']['sent'] = (aggreg[smscid]['sms'].get('sent', 0)

--- a/kannel_exporter.py
+++ b/kannel_exporter.py
@@ -3,7 +3,7 @@
 """Prometheus custom collector for Kannel gateway
 https://github.com/apostvav/kannel_exporter"""
 
-__version__ = '0.3.3'
+__version__ = '0.4.0'
 
 import argparse
 import logging
@@ -158,7 +158,7 @@ class KannelCollector:
         if not uptime:
             return 0
 
-        uptime = uptime[0]
+        uptime = int(uptime[0])
 
         if 'uptime' not in smsc_details or uptime < smsc_details['uptime']:
             return uptime

--- a/test.py
+++ b/test.py
@@ -23,11 +23,9 @@ class KannelCollectorTestCase(unittest.TestCase):
         uptime1 = uptime_to_secs("running, uptime 0d 1h 16m 31s")
         uptime2 = uptime_to_secs("running, uptime 0d 0h 1m 38s")
         uptime3 = uptime_to_secs("on-line 0d 0h 1m 53s")
-        uptime4 = uptime_to_secs("connecting")
         self.assertEqual(uptime1, 4591)
         self.assertEqual(uptime2, 98)
         self.assertEqual(uptime3, 113)
-        self.assertEqual(uptime4, 0)
 
     def test_kannel_collector(self):
         exporter = KannelCollector('', '')
@@ -175,15 +173,15 @@ Using native malloc."""
         self.assertEqual(metrics['dlr_sent'].samples[3].value, 3)
 
     def test_smsc_metrics_v150(self):
-        exporter = KannelCollector('', '')
+        opts = CollectorOpts(collect_smsc_uptime=True)
+        exporter = KannelCollector('', '', opts)
         metrics = exporter.collect_smsc_stats(self.status150['gateway']['smscs']['count'],
                                               self.status150['gateway']['smscs']['smsc'])
         self.check_smsc_metrics(metrics)
 
     def test_smsc_metrics_v145(self):
-        # with open('test/v145.xml') as xml:
-        #     status = xmltodict.parse(xml.read())
-        exporter = KannelCollector('', '')
+        opts = CollectorOpts(collect_smsc_uptime=True)
+        exporter = KannelCollector('', '', opts)
         metrics = exporter.collect_smsc_stats(self.status145['gateway']['smscs']['count'],
                                               self.status145['gateway']['smscs']['smsc'])
         self.check_smsc_metrics(metrics)

--- a/test.py
+++ b/test.py
@@ -147,6 +147,12 @@ Using native malloc."""
         self.assertEqual(metrics['queued'].samples[1].value, 3)
         self.assertEqual(metrics['queued'].samples[2].value, 2)
         self.assertEqual(metrics['queued'].samples[3].value, 5)
+        self.assertEqual(metrics['uptime'].documentation,
+                         'SMSC uptime in seconds (*)')
+        self.assertEqual(metrics['uptime'].samples[0].value, 178)
+        self.assertEqual(metrics['uptime'].samples[1].value, 41)
+        self.assertEqual(metrics['uptime'].samples[2].value, 0)
+        self.assertEqual(metrics['uptime'].samples[3].value, 0)
         self.assertEqual(metrics['sms_received'].documentation,
                          'Total number of received SMS by SMSC')
         self.assertEqual(metrics['sms_received'].samples[0].value, 0)

--- a/test.py
+++ b/test.py
@@ -23,9 +23,11 @@ class KannelCollectorTestCase(unittest.TestCase):
         uptime1 = uptime_to_secs("running, uptime 0d 1h 16m 31s")
         uptime2 = uptime_to_secs("running, uptime 0d 0h 1m 38s")
         uptime3 = uptime_to_secs("on-line 0d 0h 1m 53s")
+        uptime4 = uptime_to_secs("connecting")
         self.assertEqual(uptime1, 4591)
         self.assertEqual(uptime2, 98)
         self.assertEqual(uptime3, 113)
+        self.assertEqual(uptime4, 0)
 
     def test_kannel_collector(self):
         exporter = KannelCollector('', '')
@@ -33,7 +35,7 @@ class KannelCollectorTestCase(unittest.TestCase):
 
     def test_collector_opts(self):
         opts_def = CollectorOpts()
-        opts_nondef = CollectorOpts(True, True, False, ['smsbox'])
+        opts_nondef = CollectorOpts(True, True, False, False, ['smsbox'])
         self.assertEqual(opts_def.filter_smsc, False)
         self.assertEqual(opts_def.collect_wdp, False)
         self.assertEqual(opts_def.collect_box_uptime, False)

--- a/test/v145.xml
+++ b/test/v145.xml
@@ -64,7 +64,7 @@
 		<name>HTTP:generic:13515</name>
 		<admin-id>httpsmsc</admin-id>
 		<id>httpsmsc</id>
-		<status>online 28s</status>
+		<status>online 41s</status>
 		<failed>4</failed>
 		<queued>3</queued>
 		<sms>


### PR DESCRIPTION
Multiple boxes with same type, id and host can be connected, prior these changes, the uptime of the first occurrence used to be exposed. This changed so the lowest uptime value will be exposed instead.

A new cmd option added, `--collect-smsc-uptime`. If this option is enabled, metrics will be exposed with the lowest uptime value for each smsc id.